### PR TITLE
replace deprecated call to loadContract

### DIFF
--- a/blank_react_project/src/index.js
+++ b/blank_react_project/src/index.js
@@ -19,10 +19,11 @@ async function InitContract() {
     window.accountId = window.walletAccount.getAccountId();
 
     // Initializing our contract APIs by contract name and configuration.
-    window.contract = await window.near.loadContract(window.nearConfig.contractName, {
+    let acct = await new nearlib.Account(window.near.connection, window.accountId);
+    window.contract = await new nearlib.Contract(acct, window.nearConfig.contractName, {
         // View methods are read only. They don't modify the state, but usually return some value.
         viewMethods: ['welcome',],
-            // Change methods can modify the state. But you don't receive the returned value when called.
+        // Change methods can modify the state. But you don't receive the returned value when called.
         changeMethods: [],
         // Sender is the account ID to initialize transactions.
         sender: window.accountId


### PR DESCRIPTION
Very simple deprecation replacement. I'm new to NEAR Protocol's codebase, but this seems like a quick fix.