### PR TITLE
Switch deps to use a stricter range on versions

### DIFF
--- a/blank_project/package.json
+++ b/blank_project/package.json
@@ -19,14 +19,14 @@
     "gulp": "^4.0.2",
     "jest": "^25.1.0",
     "jest-environment-node": "^25.1.0",
-    "near-bindgen-as": "^1.2.0",
-    "near-runtime-ts": "^0.6.0",
-    "near-shell": "^0.20.1",
+    "near-bindgen-as": "~1.2.0",
+    "near-runtime-ts": "~0.6.0",
+    "near-shell": "~0.20.1",
     "nodemon": "^2.0.2",
     "parcel-bundler": "^1.12.4"
   },
   "dependencies": {
-    "nearlib": "^0.21.0",
+    "nearlib": "~0.21.0",
     "regenerator-runtime": "^0.13.3"
   }
 }

--- a/blank_react_project/package.json
+++ b/blank_react_project/package.json
@@ -22,15 +22,15 @@
     "gulp": "^4.0.2",
     "jest": "^25.1.0",
     "jest-environment-node": "^25.1.0",
-    "near-bindgen-as": "^1.2.0",
-    "near-runtime-ts": "^0.6.0",
-    "near-shell": "^0.20.1",
+    "near-bindgen-as": "~1.2.0",
+    "near-runtime-ts": "~0.6.0",
+    "near-shell": "~0.20.1",
     "nodemon": "^2.0.2",
     "parcel-bundler": "^1.12.4",
     "react-test-renderer": "^16.12.0"
   },
   "dependencies": {
-    "nearlib": "^0.21.0",
+    "nearlib": "~0.21.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "regenerator-runtime": "^0.13.3"

--- a/contract/asc/types.d.ts
+++ b/contract/asc/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="near-runtime-ts/assembly/as_types" />


### PR DESCRIPTION
Before it was "^1.0.0" ~= ">=1.0.0 " and "<2.0.0",
Now it's "~1.0.0" ~= " >=1.0.0" and "<1.1.0".  This will ensure that new installs don't update any breaking changes.

I will release a`near-devtools` package to ensure that all interdependent deps are upgraded together, but before then I will be updating packages with breaking changes and don't want users to use the any of the new versions before its ready.