### PR TITLE
package.json engine for node >= 12, better keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
   "license": "MIT",
   "keywords": [
     "nearprotocol",
-    "assembly",
+    "near-protocol",
+    "assemblyscript",
+    "rust",
+    "react",
+    "smart-contract",
     "blockchain"
   ],
   "bugs": "https://github.com/nearprotocol/blank_template.git/issues",
@@ -27,5 +31,8 @@
   },
   "devDependencies": {
     "eslint": "^6.8.0"
+  },
+  "engines": {
+    "node": ">=12"
   }
 }


### PR DESCRIPTION
I have this [in another PR](https://github.com/nearprotocol/create-near-app/pull/138) that's await approval, but I think it's very important to have the `engines` key specified for the node versions. Peter already ran into this as a problem. I want to fast track this change.
Also, while I was in there I improved some of the keywords. `assembly` for instance, is not a good keyword for us.