### PR TITLE
Travis, check multiple OSes, conditions installing npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then HOME="/c/Users/travis" && export NVS_HOME=$ProgramData/nvs && git clone --single-branch https://github.com/jasongin/nvs $NVS_HOME && source $NVS_HOME/nvs.sh && nvs --version && nvs add 12 && nvs use 12; fi
   - if [[ ! "$TRAVIS_OS_NAME" == "windows" ]]; then nvm install 12 && nvm use 12; fi
   - npm install -g yarn
+  - yarn
 script:
   - yarn test
   - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,19 @@ language: rust
 rust:
   - stable
   - nightly
-
+os:
+  - linux
+  - osx
+  - windows
 env:
-  - NODE_ENV=ci
-  - NODE_ENV=ci-staging
-cache: yarn
-
+  - NODE_ENV=ci YARN_GPG=no
+  - NODE_ENV=ci-staging YARN_GPG=no
+cache: cargo
 before_install:
   - rustup target add wasm32-unknown-unknown
-  - nvm install 12
-  - nvm use 12
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then HOME="/c/Users/travis" && export NVS_HOME=$ProgramData/nvs && git clone --single-branch https://github.com/jasongin/nvs $NVS_HOME && source $NVS_HOME/nvs.sh && nvs --version && nvs add 12 && nvs use 12; fi
+  - if [[ ! "$TRAVIS_OS_NAME" == "windows" ]]; then nvm install 12 && nvm use 12; fi
   - npm install -g yarn
-
-install:
-  - yarn install
-
 script:
   - yarn test
   - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_install:
   - if [[ ! "$TRAVIS_OS_NAME" == "windows" ]]; then nvm install 12 && nvm use 12; fi
   - npm install -g yarn
   - yarn
+git:
+  autocrlf: false
 script:
   - yarn test
   - yarn lint


### PR DESCRIPTION
This adds multiple operating systems to the list of those checked by Travis.
Also has conditionals for Windows and non-Windows in order to install npm, which installs yarn.
And add `cache: cargo` as recommended here:
https://docs.travis-ci.com/user/languages/rust/