### PR TITLE
travis: remove rust nightly check, check stable only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 rust:
   - stable
-  - nightly
 os:
   - linux
   - osx


### PR DESCRIPTION
As we mentioned internally, having Travis check the Rust nightly every time is overkill. We have discussed the possibility of having this check in a nightly CI.
At this time, the decision has been to remove nightly as we're using Rust `stable` anyway.
This will cut the number of CI tests in half.